### PR TITLE
chore: update garge-app to v1.13.0

### DIFF
--- a/charts/garge-app/Chart.yaml
+++ b/charts/garge-app/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.24
+version: 0.1.25

--- a/charts/garge-app/values.yaml
+++ b/charts/garge-app/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/garge-app
   pullPolicy: IfNotPresent
-  tag: "v1.12.1"
+  tag: "v1.13.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `garge-app` image tag to `v1.13.0` and bumps chart version to `0.1.25`.