### PR TITLE
chore: update garge-api to v2.5.0

### DIFF
--- a/charts/garge-api/Chart.yaml
+++ b/charts/garge-api/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.32
+version: 0.1.33

--- a/charts/garge-api/values.yaml
+++ b/charts/garge-api/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/garge-api
   pullPolicy: IfNotPresent
-  tag: "v2.4.1"
+  tag: "v2.5.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `garge-api` image tag to `v2.5.0` and bumps chart version to `0.1.33`.