### PR TITLE
chore: update garge-api to v2.5.0

### DIFF
--- a/charts/garge-api/Chart.yaml
+++ b/charts/garge-api/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.33
+version: 0.1.34


### PR DESCRIPTION
Updates `garge-api` image tag to `v2.5.0` and bumps chart version to `0.1.34`.