### PR TITLE
chore: update garge-app to v1.14.0

### DIFF
--- a/charts/garge-app/Chart.yaml
+++ b/charts/garge-app/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.27
+version: 0.1.28


### PR DESCRIPTION
Updates `garge-app` image tag to `v1.14.0` and bumps chart version to `0.1.28`.