### PR TITLE
ci: add reusable Dependabot PR title formatter

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -1,0 +1,28 @@
+name: 📝 Format Dependabot PR titles
+
+on:
+  workflow_call:
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add backticks around package name
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ github.event.pull_request.title }}
+          NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$TITLE" == *'`'* ]]; then
+            echo "Already formatted, skipping"
+            exit 0
+          fi
+          new_title=$(printf '%s' "$TITLE" | sed -E 's/^deps: [Bb]ump ([^ ]+)( from .+)$/deps: bump `\1`\2/')
+          if [[ "$new_title" == "$TITLE" ]]; then
+            echo "Title pattern did not match, skipping"
+            exit 0
+          fi
+          gh pr edit "$NUMBER" --title "$new_title" --repo "$REPO"


### PR DESCRIPTION
Adds a `workflow_call` reusable workflow that wraps the Dependabot package name in backticks and normalizes the verb to lowercase `bump` (Dependabot emits `Bump`). Consumed by garge-app, garge-api and garge-operator via thin caller stubs. Merge this first so the @main reference resolves.