### PR TITLE
chore: update garge-app to v1.18.3

### DIFF
--- a/charts/garge-app/Chart.yaml
+++ b/charts/garge-app/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.34
+version: 0.1.35

--- a/charts/garge-app/values.yaml
+++ b/charts/garge-app/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/garge-app
   pullPolicy: IfNotPresent
-  tag: "v1.18.1"
+  tag: "v1.18.3"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `garge-app` image tag to `v1.18.3` and bumps chart version to `0.1.35`.