### PR TITLE
feat: add podLabels support to garge-api and garge-operator charts

### DIFF
--- a/charts/garge-api/Chart.yaml
+++ b/charts/garge-api/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.44
+version: 0.1.45

--- a/charts/garge-api/templates/deployment.yaml
+++ b/charts/garge-api/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       {{- end }}
       labels:
         {{- include "garge-api.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/garge-api/values.yaml
+++ b/charts/garge-api/values.yaml
@@ -13,6 +13,8 @@ serviceAccount: {}
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
 
 securityContext: {}

--- a/charts/garge-operator/Chart.yaml
+++ b/charts/garge-operator/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.28
+version: 0.1.29

--- a/charts/garge-operator/templates/deployment.yaml
+++ b/charts/garge-operator/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       {{- end }}
       labels:
         {{- include "garge-operator.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/garge-operator/values.yaml
+++ b/charts/garge-operator/values.yaml
@@ -13,6 +13,8 @@ serviceAccount: {}
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
 
 securityContext: {}


### PR DESCRIPTION
Adds `.Values.podLabels` rendering to the pod template labels for garge-api and garge-operator, so pods can carry a `logformat: serilog` label. Alloy uses that label to scope its Serilog multiline-join + level-parsing stage (fixes multi-line EF Core SQL logs being split into one Loki entry per line).

- garge-api 0.1.44 -> 0.1.45
- garge-operator 0.1.28 -> 0.1.29