### PR TITLE
fix: support scoped prefixes in dependabot title formatter

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -20,7 +20,7 @@ jobs:
             echo "Already formatted, skipping"
             exit 0
           fi
-          new_title=$(printf '%s' "$TITLE" | sed -E 's/^deps: [Bb]ump ([^ ]+)( from .+)$/deps: bump `\1`\2/')
+          new_title=$(printf '%s' "$TITLE" | sed -E 's/^deps(\([^)]+\))?: [Bb]ump ([^ ]+)( from .+)$/deps\1: bump `\2`\3/')
           if [[ "$new_title" == "$TITLE" ]]; then
             echo "Title pattern did not match, skipping"
             exit 0


### PR DESCRIPTION
## What
Allow optional Conventional Commits scope in the Dependabot title-rewrite regex.

## Why
Scoped titles like `deps(github-actions): bump actions/checkout from 7.0.0 to 7.0.1` did not match the old regex (`^deps: [Bb]ump ...`), so the package name never got backticks.

## How
Added optional scope group `(\([^)]+\))?` and preserve it in the replacement.

Verified:
- `deps(github-actions): bump actions/checkout ...` → `` deps(github-actions): bump `actions/checkout` ... ``
- `deps: bump lodash ...` → still works
