### PR TITLE
fix: format scoped Dependabot titles and strip group suffix

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -20,7 +20,7 @@ jobs:
             echo "Already formatted, skipping"
             exit 0
           fi
-          new_title=$(printf '%s' "$TITLE" | sed -E 's/^deps: [Bb]ump ([^ ]+)( from .+)$/deps: bump `\1`\2/')
+          new_title=$(printf '%s' "$TITLE" | sed -E 's/^deps(\([^)]+\))?: [Bb]ump ([^ ]+)( from [^ ]+ to [^ ]+)( in the .+ group across [0-9]+ director(y|ies))?$/deps\1: bump `\2`\3/')
           if [[ "$new_title" == "$TITLE" ]]; then
             echo "Title pattern did not match, skipping"
             exit 0


### PR DESCRIPTION
## What
Improve the Dependabot PR title formatter to handle scoped and grouped update titles.

Supersedes #121 (includes that change plus group-suffix stripping).

## Changes
- Support optional Conventional Commits scope, e.g. `deps(npm):`, `deps(github-actions):`.
- Add backticks around the package name.
- Strip the trailing ` in the <group> group across N director(y|ies)` suffix from grouped update titles (group name and directory count vary).

## Verified
- `deps(npm): bump body-parser from 1.20.5 to 1.20.6 in the npm_and_yarn group across 1 directory` → `` deps(npm): bump `body-parser` from 1.20.5 to 1.20.6 ``
- `deps(github-actions): bump actions/checkout from 7.0.0 to 7.0.1` → `` deps(github-actions): bump `actions/checkout` from 7.0.0 to 7.0.1 ``
- `deps: bump lodash from 4.17.20 to 4.17.21` → `` deps: bump `lodash` from 4.17.20 to 4.17.21 ``
- `deps: bump foo from 1.0 to 2.0 in the some_grp group across 3 directories` → `` deps: bump `foo` from 1.0 to 2.0 ``
