### PR TITLE
chore: update garge-operator to v1.9.2

### DIFF
--- a/charts/garge-operator/Chart.yaml
+++ b/charts/garge-operator/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.1.31
+version: 0.1.32

--- a/charts/garge-operator/values.yaml
+++ b/charts/garge-operator/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: sondresjo/garge-operator
   pullPolicy: IfNotPresent
-  tag: "v1.9.1"
+  tag: "v1.9.2"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Updates `garge-operator` image tag to `v1.9.2` and bumps chart version to `0.1.32`.